### PR TITLE
vue-inifinite-loadingでSSRをするとエラーになるのでno-ssrタグで囲む

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -27,7 +27,9 @@
             </v-list-tile>
             <v-divider v-if="index + 1 < articles.length" :key="`divider-${index}`"></v-divider>
           </template>
-          <infinite-loading @infinite="infiniteHandler"></infinite-loading>
+          <no-ssr>
+            <infinite-loading @infinite="infiniteHandler"></infinite-loading>
+          </no-ssr>
         </v-list>
       </v-card>
     </v-flex>


### PR DESCRIPTION
## このPRで解決すること
以下エラーを解決する

```js
[Vue warn]: Error in beforeCreate hook: "ReferenceError: document is not defined"

found in

---> <InfiniteLoading>
       <VList>
         <VCard>
           <Pages/index.vue> at pages/index.vue
             <Nuxt>
               <Default> at layouts/default.vue
                 <Root>
{ ReferenceError: document is not defined
```

### 参考
* [GitHub Issuesでブログを作る \- Qiita](https://qiita.com/miyaoka/items/1922d5d8528fe31016b9)
* [API: <no\-ssr> コンポーネント \- Nuxt\.js](https://ja.nuxtjs.org/api/components-no-ssr/)